### PR TITLE
27.0.91; Tutorial reports false positive key rebindings

### DIFF
--- a/lisp/tutorial.el
+++ b/lisp/tutorial.el
@@ -423,11 +423,9 @@ where
 	       ;; Handle prefix definitions specially
 	       ;; so that a mode that rebinds some subcommands
 	       ;; won't make it appear that the whole prefix is gone.
-	       (key-fun (if (eq def-fun 'ESC-prefix)
-			    (lookup-key global-map [27])
-			  (if (eq def-fun 'Control-X-prefix)
-			      (lookup-key global-map [24])
-			    (key-binding key))))
+               (key-fun (if (keymapp def-fun)
+                            (lookup-key global-map key)
+                          (key-binding key)))
 	       (where (where-is-internal (if rem-fun rem-fun def-fun)))
 	       cwhere)
 


### PR DESCRIPTION
Severity: minor
Tags: patch

In some cases the tutorial can falsely claim that a user's modified key
bindings no longer correspond to the tutorial's text:

0. emacs -Q
1. M-x winner-mode RET
2. C-h t

The user is then presented with the following:

 NOTICE: The main purpose of the Emacs tutorial is to teach you
 the most important standard Emacs commands (key bindings).
 However, your Emacs has been customized by changing some of
 these basic editing commands, so it doesn't correspond to the
 tutorial.  We have inserted colored notices where the altered
 commands have been introduced. [More]

Yet no such coloured notices are to be found in TUTORIAL, since
winner-mode binds only 'C-c <left>' and 'C-c <right>', neither of which
is mentioned in the tutorial.

Pushing the "More" button gives the following *Help* buffer contents:

--8<---------------cut here---------------start------------->8---
The following key bindings used in the tutorial have been changed
from the Emacs default:

   Standard Key   Command                     In Your Emacs   
   C-c 		  mode-specific-command-prefix M-x mode-specific-command-prefix more info

It is OK to change key bindings, but changed bindings do not
correspond to what the tutorial says.
--8<---------------cut here---------------end--------------->8---

Pushing the "more info" button in turn gives the following *Help* text:

--8<---------------cut here---------------start------------->8---
Your Emacs customizations override the default binding for this key:

The default Emacs binding for the key C-c is the command
‘mode-specific-command-prefix’.  However, your customizations have
rebound it to the command ‘(keymap (keymap (right . winner-redo) (left
. winner-undo)) mode-specific-command-prefix)’.
--8<---------------cut here---------------end--------------->8---

The following patch fixes this:



I don't think this qualifies as urgent enough for inclusion in emacs-27,
but I think the fix is harmless enough if desired.  WDYT?

Thanks,

-- 
Basil

In GNU Emacs 27.0.91 (build 1, x86_64-pc-linux-gnu, X toolkit, Xaw3d scroll bars)
 of 2020-04-17 built on thunk
Repository revision: c36c5a3dedbb2e0349be1b6c3b7567ea7b594f1c
Repository branch: emacs-27
Windowing system distributor 'The X.Org Foundation', version 11.0.12008000
System Description: Debian GNU/Linux bullseye/sid

Recent messages:
For information about GNU Emacs and the GNU system, type C-h C-a.
Winner mode enabled
Preparing tutorial ...

Configured using:
 'configure 'CC=ccache gcc' 'CFLAGS=-O0 -g3 -ggdb -gdwarf-4'
 --config-cache --prefix=/home/blc/.local --program-suffix=27
 --enable-checking=yes,glyphs --enable-check-lisp-object-type
 --with-x-toolkit=lucid --with-file-notification=yes --with-x'

Configured features:
XAW3D XPM JPEG TIFF GIF PNG RSVG SOUND GPM DBUS GSETTINGS GLIB NOTIFY
INOTIFY ACL LIBSELINUX GNUTLS LIBXML2 FREETYPE HARFBUZZ M17N_FLT LIBOTF
XFT ZLIB TOOLKIT_SCROLL_BARS LUCID X11 XDBE XIM MODULES THREADS
LIBSYSTEMD JSON PDUMPER LCMS2 GMP

Important settings:
  value of $LANG: en_IE.UTF-8
  locale-coding-system: utf-8-unix

Major mode: Fundamental

Minor modes in effect:
  winner-mode: t
  tooltip-mode: t
  global-eldoc-mode: t
  electric-indent-mode: t
  mouse-wheel-mode: t
  tool-bar-mode: t
  menu-bar-mode: t
  file-name-shadow-mode: t
  global-font-lock-mode: t
  blink-cursor-mode: t
  auto-composition-mode: t
  auto-encryption-mode: t
  auto-compression-mode: t
  line-number-mode: t
  transient-mark-mode: t

Load-path shadows:
None found.

Features:
(shadow sort mail-extr emacsbug message rmc puny dired dired-loaddefs
format-spec rfc822 mml mml-sec password-cache epa derived epg epg-config
gnus-util rmail rmail-loaddefs text-property-search time-date subr-x seq
byte-opt gv bytecomp byte-compile cconv mm-decode mm-bodies mm-encode
mail-parse rfc2231 mailabbrev gmm-utils mailheader sendmail rfc2047
rfc2045 ietf-drums mm-util mail-prsvr mail-utils tutorial help-mode
easymenu cl-loaddefs cl-lib cus-start cus-load winner ring tooltip eldoc
electric uniquify ediff-hook vc-hooks lisp-float-type mwheel term/x-win
x-win term/common-win x-dnd tool-bar dnd fontset image regexp-opt fringe
tabulated-list replace newcomment text-mode elisp-mode lisp-mode
prog-mode register page tab-bar menu-bar rfn-eshadow isearch timer
select scroll-bar mouse jit-lock font-lock syntax facemenu font-core
term/tty-colors frame minibuffer cl-generic cham georgian utf-8-lang
misc-lang vietnamese tibetan thai tai-viet lao korean japanese eucjp-ms
cp51932 hebrew greek romanian slovak czech european ethiopic indian
cyrillic chinese composite charscript charprop case-table epa-hook
jka-cmpr-hook help simple abbrev obarray cl-preloaded nadvice loaddefs
button faces cus-face macroexp files text-properties overlay sha1 md5
base64 format env code-pages mule custom widget hashtable-print-readable
backquote threads dbusbind inotify lcms2 dynamic-setting
system-font-setting font-render-setting x-toolkit x multi-tty
make-network-process emacs)

Memory information:
((conses 16 53148 6793)
 (symbols 48 7187 1)
 (strings 32 18206 1076)
 (string-bytes 1 550231)
 (vectors 16 9603)
 (vector-slots 8 128508 8846)
 (floats 8 22 33)
 (intervals 56 228 0)
 (buffers 1000 12))
