### PR TITLE
Support ripgrep in semantic-symref-tool-grep

### DIFF
--- a/lisp/cedet/semantic/symref/grep.el
+++ b/lisp/cedet/semantic/symref/grep.el
@@ -79,16 +79,7 @@ Optional argument MODE specifies the `major-mode' to test."
                    ;; Only take in simple patterns, so try to convert this one.
                    (string-match "\\\\\\.\\([^\\'>]+\\)\\\\'" (car X)))
           (push (concat "*." (match-string 1 (car X))) pat))))
-    ;; Convert the list into some find-flags.
-    (if (null pat)
-        (error "Customize `semantic-symref-filepattern-alist' for %S"
-               major-mode)
-      (let ((args `("-name" ,(car pat))))
-        (if (null (cdr pat))
-            args
-          `("(" ,@args
-            ,@(mapcan (lambda (s) `("-o" "-name" ,s)) (cdr pat))
-            ")"))))))
+    pat))
 
 (defvar semantic-symref-grep-flags)
 
@@ -133,11 +124,90 @@ This shell should support pipe redirect syntax."
   :group 'semantic
   :type 'string)
 
+(defcustom semantic-symref-grep-tool 'auto-detect
+  "The tool to use for searching in files."
+  :type '(choice (const :tag "Auto-detect" auto-detect)
+                 (const :tag "Ripgrep" ripgrep)
+                 (const :tag "find + grep" find-grep))
+  :group 'semantic)
+
+(defcustom semantic-symref-grep-ripgrep-command "rg"
+  "Name of the ripgrep command to use."
+  :type 'file
+  :group 'semantic)
+
+(defun semantic-symref-grep--auto-detect-tool ()
+  (let ((have-rg
+         (with-temp-buffer
+           (let ((hello-file (grep-hello-file)))
+             (let ((process-file-side-effects nil))
+               (unwind-protect
+                   (eql (ignore-errors
+                          (process-file
+                           semantic-symref-grep-ripgrep-command
+                           nil t nil "^Copyright"
+                           (file-local-name hello-file)))
+                        0)
+                 (when (file-remote-p hello-file)
+                   (delete-file hello-file))))))))
+    (if have-rg
+        'ripgrep
+      'find-grep)))
+
 (defun semantic-symref-grep--quote-extended (string)
   "Quote STRING as an extended-syntax regexp."
   (replace-regexp-in-string (rx (in ".^$*+?|{}[]()|\\"))
                             (lambda (s) (concat "\\" s))
                             string nil t))
+
+(defun semantic-symref-grep--command (rootdir filepatterns file-name-only
+                                      pattern-type pattern)
+  "Compute search command to run.
+ROOTDIR is the root of the tree to search.  FILEPATTERNS is a
+list of glob patterns that match the files to search.
+If FILE-NAME-ONLY is non-nil, the search only wants the names of files.
+PATTERN-TYPE indicates the type of PATTERN:
+ `regexp'     -- PATTERN is an extended (egrep) regexp.
+ `symbol'     -- PATTERN is a literal identifier.
+
+Return the command and arguments as a list of strings."
+  (when (eq semantic-symref-grep-tool 'auto-detect)
+    (setq semantic-symref-grep-tool
+          (semantic-symref-grep--auto-detect-tool)))
+  (cond
+   ((eq semantic-symref-grep-tool 'ripgrep)
+    (let ((filepat-args
+           (mapcan (lambda (s) (list "-g" s)) filepatterns))
+          (flags (cond (file-name-only "-l")
+                       ((eq pattern-type 'symbol) "-nw")
+                       (t "-n")))
+          (pat-arg (if (eq pattern-type 'symbol)
+                       (semantic-symref-grep--quote-extended pattern)
+                     pattern))
+          (dir (expand-file-name rootdir)))
+      `(,semantic-symref-grep-ripgrep-command
+        ,@filepat-args ,flags "-e" ,pat-arg ,dir)))
+   (t
+    (let* ((filepat-args
+            ;; Convert the list into some find-flags.
+            (let ((args `("-name" ,(car filepatterns))))
+              (if (cdr filepatterns)
+                  `("(" ,@args
+                    ,@(mapcan (lambda (s) (list "-o" "-name" s))
+                              (cdr filepatterns))
+                    ")")
+                args)))
+           (filepattern (mapconcat #'shell-quote-argument filepat-args " "))
+           (grepflags (cond (file-name-only "-l ")
+                            ((eq pattern-type 'regexp) "-nE ")
+                            (t "-nwE ")))
+           (pat-arg (if (eq pattern-type 'symbol)
+                        (semantic-symref-grep--quote-extended pattern)
+                      pattern))
+           (cmd (semantic-symref-grep-use-template
+                 (directory-file-name (file-local-name rootdir))
+                 filepattern grepflags pat-arg)))
+      `(,semantic-symref-grep-shell ,shell-command-switch ,cmd)))))
 
 (cl-defmethod semantic-symref-perform-search ((tool semantic-symref-tool-grep))
   "Perform a search with Grep."
@@ -150,33 +220,18 @@ This shell should support pipe redirect syntax."
   (let* (;; Find the file patterns to use.
 	 (rootdir (semantic-symref-calculate-rootdir))
 	 (filepatterns (semantic-symref-derive-find-filepatterns))
-         (filepattern (mapconcat #'shell-quote-argument filepatterns " "))
-	 ;; Grep based flags.
-	 (grepflags (cond ((eq (oref tool resulttype) 'file)
-                           "-l ")
-                          ((eq (oref tool searchtype) 'regexp)
-                           "-nE ")
-                          (t "-nw ")))
-         (searchfor (oref tool searchfor))
-         (greppat (if (eq (oref tool searchtype) 'regexp)
-                      searchfor
-                    (semantic-symref-grep--quote-extended searchfor)))
-	 ;; Misc
-	 (b (get-buffer-create "*Semantic SymRef*"))
-	 (ans nil)
-	 )
+         (greppat (oref tool searchfor))
+         (file-names-only (eq (oref tool resulttype) 'file))
+         (search-type (oref tool searchtype))
+         (command (semantic-symref-grep--command
+                   rootdir filepatterns file-names-only search-type greppat))
+	 (b (get-buffer-create "*Semantic SymRef*")))
 
     (with-current-buffer b
       (erase-buffer)
       (setq default-directory rootdir)
-      (let ((cmd (semantic-symref-grep-use-template
-                  (directory-file-name (file-local-name rootdir))
-                  filepattern grepflags greppat)))
-        (process-file semantic-symref-grep-shell nil b nil
-                      shell-command-switch cmd)))
-    (setq ans (semantic-symref-parse-tool-output tool b))
-    ;; Return the answer
-    ans))
+      (apply #'process-file (car command) nil b nil (cdr command)))
+    (semantic-symref-parse-tool-output tool b)))
 
 (cl-defmethod semantic-symref-parse-tool-output-one-line ((tool semantic-symref-tool-grep))
   "Parse one line of grep output, and return it as a match list.


### PR DESCRIPTION
Creating a separate bug report from bug#49731 because this is a real problem.

Now grep.el completely supports ripgrep when 'grep-find-template'
is customized to a command line that uses 'rg' such as e.g.

  "find <D> <X> -type f <F> -print0 | sort -z | xargs -0 -e
   rg <C> -nH --no-heading -j8 --sort path -M 200 --max-columns-preview -e <R>"

But such grep setting breaks the command 'xref-find-references':

>>>> 1. while xref-find-references works fine in `emacs -Q`,
>>>> I don't know why with my customization typing e.g.
>>>> 'M-? isearch-lazy-highlight RET' reports
>>>> "No references found for: isearch-lazy-highlight".
>>>
>>> Try and see which of the "tools" semantic-symref-perform-search ends
>>> up using.
>>
>> Thanks for the pointers to semantic-symref-perform-search.
>> It prepends "-n " to my customized pattern "rg -nH",
>> so the arg "-n" is duplicated on the command line:
>>    `rg -n -nH`
>> and signals the error:
>>    error: The argument '--line-number' was provided more than once, but
>> cannot be used multiple times
>> This error is caused by the bug in the command line parser used by
>> ripgrep:
>>    https://github.com/clap-rs/clap/issues/2171
>> that was fixed only 6 months ago, so it will take much time
>> before this fix will reach ripgrep, and this bug will be closed:
>>    https://github.com/BurntSushi/ripgrep/issues/1701
>
> The above might be worked around with creating a symref-grep specific user
> option for grep-find-template which would default to the "global" value of
> that variable.

Maybe like the existing option 'semantic-symref-grep-shell', e.g.:

  (defcustom semantic-symref-grep-program 'grep
    "The program to use for regexp search inside files."
    :type `(choice
            (const :tag "Use Grep" grep)
            (const :tag "Use ripgrep" ripgrep)
            (symbol :tag "User defined"))
    :version "28.1")

But the problem is that for users it's hard to see the connection
between the broken 'xref-find-references' and the need to customize an option
with unrelated name 'semantic-symref-grep'.

>> But even without duplicated "-n" semantic-symref-perform-search
>> doesn't work with ripgrep because it doesn't find such pattern:
>>    \\\\\\(\\^\\\\\\|\\\\W\\\\\\)isearch-lazy-highlight\\\\\\(\\\\W\\\\\\|\\$\\\\\\)
>> Maybe semantic-symref-perform-search could be improved to
>> support ripgrep?
>> Because without these two problems it works fine with ripgrep.
>
> ...but the above tells us (I think) that semantic-symref-perform-search is
> trying to use the basic regexp syntax, and ripgrep doesn't support that
> (only Extended, or PCRE).
>
> For your personal consumption, perhaps the best approach is to create
> a separate "tool", like Grep (by copying symref/grep.el and tweaking some
> of its definitions), and then register it in semantic-symref-tool-alist.
>
> I don't know if ripgrep is that much faster for this particular purpose. So
> maybe it's too much work for little benefit.

A more general solution would be to add to grep.el the same options
that you added to xref:

  xref-search-program grep/ripgrep
  xref-search-program-alist
    '((grep . "xargs -0 grep <C> -snHE -e <R>")
      (ripgrep . "xargs -0 rg <C> -nH --no-messages -g '!*/' -e <R> | sort -t: -k1,1 -k2n,2"))

This means to turn the existing variable 'grep-program' into the user option
as the following patch does.

Also later grep.el could use the value "rg" of 'grep-program'
to create the corresponding grep-find-template in grep-compute-defaults.

But I don't know if it's ok to mention rigrep in grep.el?

Anyway, here is the patch that fixes 'xref-find-references':

