### PR TITLE
27.2; [PATCH] Undoing a 'RET' in comint and eshell

### DIFF
--- a/lisp/comint.el
+++ b/lisp/comint.el
@@ -1891,6 +1891,14 @@ Similarly for Soar, Scheme, etc."
                           (delete-region pmark start)
                           copy))))
 
+        ;; Delete and reinsert input.  This seems like a no-op, except
+        ;; for the resulting entries in the undo list: undoing this
+        ;; insertion will delete the region, moving the process mark
+        ;; back to its original position.
+        (let ((inhibit-read-only t))
+          (delete-region pmark (point))
+          (insert input))
+
         (unless no-newline
           (insert ?\n))
 
@@ -1934,7 +1942,7 @@ Similarly for Soar, Scheme, etc."
         ;; in case we get output amidst sending the input.
         (set-marker comint-last-input-start pmark)
         (set-marker comint-last-input-end (point))
-        (set-marker (process-mark proc) (point))
+        (set-marker pmark (point))
         ;; clear the "accumulation" marker
         (set-marker comint-accum-marker nil)
         (let ((comint-input-sender-no-newline no-newline))
@@ -3495,6 +3503,20 @@ to send all the accumulated input, at once.
 The entire accumulated text becomes one item in the input history
 when you send it."
   (interactive)
+  (when-let* ((proc (get-buffer-process (current-buffer)))
+              (pmark (process-mark proc))
+              ((or (marker-position comint-accum-marker)
+                   (set-marker comint-accum-marker pmark)
+                   t))
+              ((>= (point) comint-accum-marker pmark)))
+    ;; Delete and reinsert input.  This seems like a no-op, except for
+    ;; the resulting entries in the undo list: undoing this insertion
+    ;; will delete the region, moving the accumulation marker back to
+    ;; its original position.
+    (let ((text (buffer-substring comint-accum-marker (point)))
+          (inhibit-read-only t))
+      (delete-region comint-accum-marker (point))
+      (insert text)))
   (insert "\n")
   (set-marker comint-accum-marker (point))
   (if comint-input-ring-index

--- a/lisp/eshell/esh-mode.el
+++ b/lisp/eshell/esh-mode.el
@@ -614,6 +614,14 @@ newline."
 		  (and eshell-send-direct-to-subprocesses
 		       proc-running-p))
 	(insert-before-markers-and-inherit ?\n))
+      ;; Delete and reinsert input.  This seems like a no-op, except
+      ;; for the resulting entries in the undo list: undoing this
+      ;; insertion will delete the region, moving the process mark
+      ;; back to its original position.
+      (let ((text (buffer-substring eshell-last-output-end (point)))
+            (inhibit-read-only t))
+        (delete-region eshell-last-output-end (point))
+        (insert text))
       (if proc-running-p
 	  (progn
 	    (eshell-update-markers eshell-last-output-end)


### PR DESCRIPTION
1) M-x shell
2) echo foo RET
3) C-/ to undo this 'RET'
   The buffer now contain the shell's prompt and "echo foo".
   However, the process mark is located at eob after "echo foo"
4) Type bar
   The buffer now contain the shell's prompt and "echo foobar"
5) RET
   Shell will output "bar: command not found", because the process mark
   is located before "bar" after "foo".

Similar behaviour can be observed with C-c SPC (comint-accumulate) and
with eshell.

My idea to solve this is to record process mark and related marker
positions as `apply' entries in the undo list. Attached patch implements
this for comint and eshell.
