### PR TITLE
[PATCH] 28.0.50; electric-pair-mode fails to pair double quotes in some cases in CC mode

### DIFF
--- a/lisp/progmodes/cc-mode.el
+++ b/lisp/progmodes/cc-mode.el
@@ -2549,17 +2549,24 @@ This function is called from `c-common-init', once per mode initialization."
 
 At the time of call, point is just after the newly inserted CHAR.
 
-When CHAR is \", t will be returned unless the \" is marked with
-a string fence syntax-table text property.  For other characters,
-the default value of `electric-pair-inhibit-predicate' is called
-and its value returned.
+When CHAR is \" and not within a comment, t will be returned if
+the quotes on the current line are already balanced (i.e. if the
+last \" is not marked with a string fence syntax-table text
+property).  For other cases, the default value of
+`electric-pair-inhibit-predicate' is called and its value
+returned.
 
 This function is the appropriate value of
 `electric-pair-inhibit-predicate' for CC Mode modes, which mark
 invalid strings with such a syntax table text property on the
 opening \" and the next unescaped end of line."
-  (if (eq char ?\")
-      (not (equal (get-text-property (1- (point)) 'c-fl-syn-tab) '(15)))
+  (if (and (eq char ?\")
+	   (not (memq (cadr (c-semi-pp-to-literal (1- (point)))) '(c c++))))
+      (let ((last-quote (save-match-data
+			  (save-excursion
+			    (goto-char (c-point 'eoll))
+			    (search-backward "\"")))))
+	(not (equal (c-get-char-property last-quote 'c-fl-syn-tab) '(15))))
     (funcall (default-value 'electric-pair-inhibit-predicate) char)))
 
 

--- a/test/lisp/electric-tests.el
+++ b/test/lisp/electric-tests.el
@@ -32,6 +32,9 @@
 (require 'elec-pair)
 (require 'cl-lib)
 
+;; When running tests in c-mode, use single-line comments (//).
+(add-hook 'c-mode-hook (lambda () (c-toggle-comment-style -1)))
+
 (defun call-with-saved-electric-modes (fn)
   (let ((saved-electric (if electric-pair-mode 1 -1))
         (saved-layout (if electric-layout-mode 1 -1))
@@ -176,7 +179,7 @@ The buffer's contents should %s:
           expected-string
           expected-point
           bindings
-          (modes '(quote (ruby-mode js-mode python-mode)))
+          (modes '(quote (ruby-mode js-mode python-mode c-mode)))
           (test-in-comments t)
           (test-in-strings t)
           (test-in-code t)


### PR DESCRIPTION
(Note: I've just updated my copyright assignment information, but 
haven't received confirmation that everything is in order, so this might 
need to wait until that's done for it to merge.)

There are a few related issues with pairing double quotes in CC mode 
while using `electric-pair-mode'. Hopefully the steps to reproduce below 
will explain the issues. In all the cases, I'd expect 
`electric-pair-mode' to insert a closing quote, but it doesn't. You can 
try similar steps in a `ruby-mode' buffer to see how it should work.

----------------------------------------

Common setup
------------

   $ cat foo.c
   "foobar"

   $ emacs -Q foo.c
   M-x electric-pair-mode

Note that | represents the point below.

1. Quote pairing in comments
----------------------------

   C-o   ;; to make a blank line
   // "  ;; type this

Expected: line 1 is // "|"
Actual:   line 1 is // "|

2. Inserting quote pairs before existing string
-----------------------------------------------

   "  ;; type this (point is at beginning of buffer, before "foobar")

Expected: line 1 is "|""foobar"
Actual:   line 1 is "|"foobar"

3. Splitting strings into two
-----------------------------

   "foo|bar"  ;; move point here
   "          ;; type this

Expected: line 1 is "foo"|"bar"
Actual:   line 1 is "foo"|bar"

----------------------------------------

This is because the logic in the patch for bug#36474 isn't quite right. 
Currently, `c-electric-pair-inhibit-predicate' checks if the 
newly-inserted quotation mark has "a string fence syntax-table text 
property" (i.e. if it's the start of a string literal not terminated on 
that line[1]). However, this fails in all three cases above: in (1) 
because we're in a comment, not a string literal; and in (2) and (3) 
because it's the *last* quotation mark on the line that's unterminated, 
not the one before point.

The attached patch fixes this by taking those cases into account. I also 
added `c-mode' to the list of modes to check in 
`test/lisp/electric-tests.el'. This required setting single-line 
comments as the default in those tests, since the tests expect 
single-line comments (I tried testing under `c++-mode', but the tests 
failed, I think due to <> being paren-like in C++).

[1] I think this is what it means, at least (or close to it).
